### PR TITLE
Update to latest react-sizeme

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",
     "react-dom": "^0.14.0 || ^15.0.0",
-    "react-sizeme": "^2.0.0"
+    "react-sizeme": "^2.3.2"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "lodash-webpack-plugin": "0.10.0",
     "mocha": "3.0.2",
     "path": "0.12.7",
+    "prop-types": "^15.0.0-0",
     "react": "15.3.1",
     "react-addons-test-utils": "15.3.1",
     "react-dom": "15.3.1",
@@ -71,6 +72,7 @@
     "webpack-hot-middleware": "2.12.2"
   },
   "peerDependencies": {
+    "prop-types": "^15.0.0-0",
     "react": "^0.14.0 || ^15.0.0",
     "react-dom": "^0.14.0 || ^15.0.0",
     "react-sizeme": "^2.3.2"

--- a/src/componentQueries.js
+++ b/src/componentQueries.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import invariant from 'invariant';
 import sizeMe from 'react-sizeme';
 import mergeWith from './utils/mergeWith';


### PR DESCRIPTION
This includes:

- Forcing react-sizeme to be above 2.3.2, with the Firefox fix
- Using PropTypes from the `prop-types` package, separated from React