### PR TITLE
fix mergeWith to keep 'falsy' properties from right side

### DIFF
--- a/src/utils/__tests__/mergeWith.test.js
+++ b/src/utils/__tests__/mergeWith.test.js
@@ -1,0 +1,68 @@
+import mergeWith from '../mergeWith'
+
+describe('When mering props with `mergeWith`', () => {
+  describe('and we are using "apply left prop" as resolver', () => {
+    const resolver = x => x
+    it('it should keep all defined values on left side.', () => {
+      const a = {
+        string: 'string',
+        zero: 0,
+        negaive: -1,
+        float: 0.555555,
+        deep: {
+          er: 'foo',
+        },
+        array: [0, 1],
+        emptyArray: [],
+      }
+      expect(mergeWith(a, {}, resolver)).toMatchObject({
+        string: 'string',
+        zero: 0,
+        negaive: -1,
+        float: 0.555555,
+        deep: {
+          er: 'foo',
+        },
+        array: [0, 1],
+        emptyArray: [],
+      })
+    })
+
+    it('it should keep all defined values on right side.', () => {
+      const b = {
+        string: 'string',
+        zero: 0,
+        negaive: -1,
+        float: 0.555555,
+        deep: {
+          er: 'foo',
+        },
+        array: [0, 1],
+        emptyArray: [],
+      }
+      expect(mergeWith({}, b, resolver)).toMatchObject({
+        string: 'string',
+        zero: 0,
+        negaive: -1,
+        float: 0.555555,
+        deep: {
+          er: 'foo',
+        },
+        array: [0, 1],
+        emptyArray: [],
+      })
+    })
+
+    it('it should copy existing values and use left one on conflict.', () => {
+      const a = {
+        string: 'string',
+      }
+      const b = {
+        string: 'my string',
+      }
+      expect(mergeWith(a, b, resolver)).toMatchObject({
+        string: 'string',
+      })
+    })
+  })
+})

--- a/src/utils/mergeWith.js
+++ b/src/utils/mergeWith.js
@@ -5,7 +5,7 @@ const mergeWith = (x, y, fn) => {
   Object.keys(y).forEach((key) => {
     if (x[key] && y[key]) {
       result[key] = fn(x[key], y[key], key)
-    } else if (y[key]) {
+    } else {
       result[key] = y[key]
     }
   })


### PR DESCRIPTION
Current code remove properties which are "falsy" like `0`.